### PR TITLE
Enable username change during onboarding

### DIFF
--- a/USERNAME-FIX-SUMMARY.md
+++ b/USERNAME-FIX-SUMMARY.md
@@ -1,0 +1,137 @@
+# Username Update Fix - Onboarding Issue ✅
+
+## Problem Description
+During onboarding, when users changed their username and the system showed it was available, the username change wasn't persisting and would revert to the original username. Users had to go to the profile settings to change their username after completing onboarding.
+
+## Root Cause Analysis
+The issue was in the username validation and submission logic in the `SimpleOnboarding` component:
+
+1. **Complex Conditional Logic**: The original logic for determining when to pass a username to `createProfile` was overly complex and error-prone
+2. **String Comparison Issues**: The comparison between current and original username wasn't accounting for trimming and potential type differences
+3. **Validation State Management**: The form validation wasn't properly synchronized with the username availability checking
+
+## Solution Implemented
+
+### 1. **Improved Username Logic in Onboarding Component**
+
+**File**: `components/onboarding/simple-onboarding.tsx`
+
+- **Added Helper Functions**: Created `isUsernameChanging()` and `isFormValidForSubmission()` for clearer logic
+- **Simplified Username Determination**: Replaced complex ternary logic with explicit cases:
+  - Case 1: User needs a username (new user without one)
+  - Case 2: User is editing their existing username
+- **Better String Handling**: Added proper trimming and comparison logic
+- **Improved Validation**: Enhanced form validation to properly handle username availability states
+
+**Before**:
+```typescript
+const usernameToUse = 
+  (needsUsername || showUsernameEdit) && values.username && values.username !== originalUsername
+    ? values.username
+    : undefined;
+```
+
+**After**:
+```typescript
+let usernameToUse: string | undefined = undefined;
+
+// Case 1: User needs a username (new user without one)
+if (needsUsername && values.username) {
+  usernameToUse = values.username.trim();
+}
+// Case 2: User is editing their existing username
+else if (showUsernameEdit && values.username && values.username.trim() !== (originalUsername || '').trim()) {
+  usernameToUse = values.username.trim();
+}
+```
+
+### 2. **Enhanced Helper Functions**
+
+Added clear helper functions to manage validation state:
+
+```typescript
+// Helper function to determine if username is actually changing
+const isUsernameChanging = () => {
+  const trimmedCurrent = (currentUsername || '').trim();
+  const trimmedOriginal = (originalUsername || '').trim();
+  return trimmedCurrent !== trimmedOriginal && trimmedCurrent.length >= 3;
+};
+
+// Helper function to check if form is valid for submission
+const isFormValidForSubmission = () => {
+  // If username is being changed, it must be available
+  if (isUsernameChanging()) {
+    return usernameAvailability.isAvailable === true && !usernameAvailability.isChecking;
+  }
+  return true;
+};
+```
+
+### 3. **Backend Validation Already Correct**
+
+The `createProfile` function in `lib/actions/profile.ts` was already correctly implemented to handle username updates atomically:
+
+- ✅ Validates username format and availability
+- ✅ Checks for reserved usernames
+- ✅ Updates username in database before creating profile
+- ✅ Handles revalidation for username changes
+- ✅ Returns proper error messages
+
+## Key Improvements
+
+### 🔧 **Better Logic Flow**
+- Clear separation between "needs username" and "editing username" cases
+- Explicit string trimming and comparison
+- Simplified conditional logic
+
+### 🎯 **Improved Validation**
+- Real-time username availability checking
+- Proper form validation state management
+- Clear visual feedback for username status
+
+### 🚀 **Enhanced User Experience**
+- Submit button properly disabled during username checking
+- Clear error messages for invalid usernames
+- Smooth transition from onboarding to dashboard
+
+### 🛡️ **Robust Error Handling**
+- Proper error handling for edge cases
+- Graceful fallbacks for validation failures
+- Clear user feedback for all scenarios
+
+## Testing Scenarios
+
+The fix addresses these key scenarios:
+
+1. **New User (No Username)**: ✅ Can set username during onboarding
+2. **OAuth User (Has Username)**: ✅ Can change username during onboarding
+3. **Username Availability**: ✅ Real-time checking with proper validation
+4. **Reserved Usernames**: ✅ Properly blocked with clear error messages
+5. **Invalid Formats**: ✅ Client and server-side validation
+6. **Edge Cases**: ✅ Handles empty strings, whitespace, and special characters
+
+## Files Modified
+
+1. **`components/onboarding/simple-onboarding.tsx`**: Enhanced username logic and validation
+2. **`lib/actions/profile.ts`**: Already had correct atomic operation handling
+
+## Benefits of This Approach
+
+✅ **Atomic Operations**: Username update and profile creation happen together  
+✅ **Clear Logic**: Easy to understand and maintain code  
+✅ **Better UX**: Immediate feedback and proper validation states  
+✅ **Robust Validation**: Both client and server-side protection  
+✅ **Error Handling**: Comprehensive error scenarios covered  
+✅ **Type Safety**: Proper TypeScript types and validation  
+
+## Verification
+
+To verify the fix works:
+
+1. **OAuth Signup**: Sign up with GitHub/Google
+2. **Change Username**: Click "Change username" during onboarding
+3. **Check Availability**: Enter a new username and verify availability checking
+4. **Submit**: Complete onboarding and verify username persists
+5. **Navigate**: Go to admin dashboard and confirm username is updated
+
+The username should now properly persist when changed during onboarding, eliminating the need to update it later in profile settings.


### PR DESCRIPTION
Fix username not updating when changed during onboarding.

The previous logic in `SimpleOnboarding` for determining when to pass the updated username to the `createProfile` function was flawed, especially for users with an initial default username (e.g., from OAuth). This prevented the new username from being persisted, requiring users to change it again in profile settings. The fix refactors the submission logic to explicitly handle username changes, ensuring the correct value is always sent to the backend.