### PR TITLE
Fix username display and portfolio link

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import React from "react";
 
 import { PostHogUserIdentifier } from "@/components/analytics/posthog-user-identifier";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
@@ -16,16 +17,17 @@ async function getAdminData() {
     redirect("/sign-in");
   }
 
-  if (!session.user.username) {
-    redirect("/onboarding");
-  }
-
   const userResult = await getUserById(session.user.id);
   if (!userResult.success || !userResult.data) {
     redirect("/sign-in");
   }
 
   const userData = userResult.data;
+
+  // Use fresh data from database instead of potentially cached session data
+  if (!userData.username) {
+    redirect("/onboarding");
+  }
 
   let isPro = false;
 
@@ -49,9 +51,9 @@ async function getAdminData() {
     userData,
     isPro,
     productInfo,
-    userName: session.user.name || "User",
-    userEmail: session.user.email || "",
-    userUsername: session.user.username || "",
+    userName: userData.name || session.user.name || "User",
+    userEmail: userData.email || session.user.email || "",
+    userUsername: userData.username || "", // Always use fresh DB data for username
   };
 }
 

--- a/components/onboarding/simple-onboarding.tsx
+++ b/components/onboarding/simple-onboarding.tsx
@@ -170,7 +170,7 @@ export function SimpleOnboarding({ user }: SimpleOnboardingProps) {
 
       toast.success("Welcome to Wrk.so! 🎉");
       router.push("/admin");
-      router.refresh();
+      router.refresh(); // Refresh to ensure admin layout gets updated session data
     } catch (error) {
       console.error("Error creating profile:", error);
       toast.error("Failed to create profile. Please try again.");

--- a/lib/utils/revalidation.ts
+++ b/lib/utils/revalidation.ts
@@ -16,9 +16,10 @@ export async function revalidateUserProfile(username: string, userId?: string) {
       revalidateTag(`projects:${userId}`);
     }
 
-    // Only revalidate specific paths that are critical
-    revalidatePath(`/${username}`);
-    revalidatePath("/admin/profile");
+      // Only revalidate specific paths that are critical
+  revalidatePath(`/${username}`);
+  revalidatePath("/admin/profile");
+  revalidatePath("/admin"); // Also revalidate admin layout
   } catch (error) {
     console.error(`Failed to revalidate profile for ${username}:`, error);
   }
@@ -66,6 +67,7 @@ export async function revalidateUsernameChange(
 
     // Critical admin paths
     revalidatePath("/admin/profile");
+    revalidatePath("/admin"); // Revalidate admin layout for sidebar updates
   } catch (error) {
     console.error(`Failed to revalidate username change:`, error);
   }

--- a/username-fix-summary.md
+++ b/username-fix-summary.md
@@ -1,0 +1,85 @@
+# Username Display and Portfolio Link Fix
+
+## Issue Description
+
+After changing username during onboarding, two problems occurred:
+1. **Admin Sidebar**: The new username was not showing on the admin sidebar
+2. **Portfolio Link**: The "View your portfolio" link was still pointing to the old username
+
+## Root Cause Analysis
+
+The issue was caused by **session caching** in the Better Auth system:
+
+1. **Session Caching**: The auth system has cookie caching enabled (5-minute cache), so session data wasn't immediately updated after username changes
+2. **Admin Layout Dependency**: The admin layout was using `session.user.username` directly instead of fresh database data
+3. **Stale Data**: Even with revalidation, the cached session data was still being used
+
+## Fixes Implemented
+
+### 1. Admin Layout Data Source Fix (`app/(admin)/layout.tsx`)
+
+**Before**: Used cached session data for username
+```typescript
+// Potentially stale session data
+userUsername: session.user.username || "",
+```
+
+**After**: Use fresh database data for username
+```typescript
+// Always use fresh DB data for username
+userUsername: userData.username || "",
+```
+
+**Changes Made**:
+- Moved username validation to use database data: `if (!userData.username)`
+- Prioritized database user data over session data for all user fields
+- Added fallbacks to session data only when database data is not available
+
+### 2. Enhanced Revalidation (`lib/utils/revalidation.ts`)
+
+**Added admin layout revalidation** to both functions:
+
+- `revalidateUserProfile()`: Added `revalidatePath("/admin")`
+- `revalidateUsernameChange()`: Added `revalidatePath("/admin")`
+
+This ensures that when usernames change, the admin layout cache is properly invalidated.
+
+### 3. Documentation (`components/onboarding/simple-onboarding.tsx`)
+
+Added clarifying comment:
+```typescript
+router.refresh(); // Refresh to ensure admin layout gets updated session data
+```
+
+## Technical Details
+
+### Session vs Database Data Priority
+
+The fix establishes this priority order for user data in admin layout:
+1. **Username**: Always from database (most critical for accuracy)
+2. **Name**: Database first, fallback to session
+3. **Email**: Database first, fallback to session
+
+### Cache Invalidation Flow
+
+1. Username change in onboarding → `createProfile()` action
+2. Database updated with new username
+3. Enhanced revalidation invalidates:
+   - User profile caches
+   - Username-specific caches  
+   - **Admin layout cache** (newly added)
+4. Admin layout refetches fresh data from database
+
+## Result
+
+✅ **Admin sidebar now shows updated username immediately**  
+✅ **Portfolio link correctly points to new username**  
+✅ **Session caching no longer causes stale data issues**
+
+## Files Modified
+
+- `app/(admin)/layout.tsx` - Use database data instead of session data
+- `lib/utils/revalidation.ts` - Enhanced cache invalidation
+- `components/onboarding/simple-onboarding.tsx` - Added documentation
+
+The fix ensures that username changes are immediately reflected in the admin interface without requiring manual page refreshes or waiting for session cache expiration.


### PR DESCRIPTION
Update admin sidebar and portfolio link to reflect immediate username changes by using fresh database data and enhancing cache revalidation.

The admin layout was displaying stale username data from a cached session, leading to incorrect display and portfolio links. This PR ensures the admin layout always fetches the latest username from the database and properly revalidates the `/admin` path after username changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Username and profile updates are now reflected immediately in the admin sidebar and portfolio link, eliminating delays caused by session caching.
  * The admin layout now displays the latest user information by prioritizing fresh database data over cached session data.

* **Documentation**
  * Added a clarifying comment in the onboarding flow to explain the need for refreshing the admin layout after profile creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->